### PR TITLE
Updated Cli.php::waitForKey

### DIFF
--- a/src/Command/Cli.php
+++ b/src/Command/Cli.php
@@ -54,10 +54,19 @@ class Cli
     /**
      * @return string
      */
-    public function waitForKey()
+    public function readCharacter()
     {
         $handle = fopen("php://stdin", "r");
         $value = fgetc($handle);
         return trim($value);
+    }
+
+    /**
+     * @return $this
+     */
+    public function waitForKey()
+    {
+        passthru('read -rsn1');
+        return $this;
     }
 }


### PR DESCRIPTION
waitForKey requires an extra enter before the key is actually read. Since im guessing you'd like to wait for 1 key rather than 2, its been changed to passthru to just listen to a keypress event. No usages of the ouput waitForKey found in the project, so $this is returned for chaining of functions. readCharacter added to replace waitForKey's original functionality.