### PR TITLE
charset for MySQL DSN as parameter

### DIFF
--- a/src/Http/Request.php
+++ b/src/Http/Request.php
@@ -21,8 +21,6 @@ class Request
      */
     public function __construct()
     {
-        $this->body = file_get_contents('php://input');
-
         if (PHP_SAPI !== "cli") {
             // @codeCoverageIgnoreStart
             $this->headers = getallheaders() ?: [];
@@ -152,6 +150,9 @@ class Request
      */
     public function getBody()
     {
+        if ($this->body === null) {
+            $this->body = file_get_contents('php://input');
+        }
         return $this->body;
     }
 

--- a/src/Http/Request.php
+++ b/src/Http/Request.php
@@ -13,11 +13,16 @@ class Request
     /** @var array */
     protected $headers = [];
 
+    /** @var string */
+    protected $body;
+
     /**
      * Set some basic information we're going to need.
      */
     public function __construct()
     {
+        $this->body = file_get_contents('php://input');
+
         if (PHP_SAPI !== "cli") {
             // @codeCoverageIgnoreStart
             $this->headers = getallheaders() ?: [];
@@ -141,4 +146,13 @@ class Request
         }
         return "http";
     }
+
+    /**
+     * @return string
+     */
+    public function getBody()
+    {
+        return $this->body;
+    }
+
 }

--- a/src/ORM/Database.php
+++ b/src/ORM/Database.php
@@ -29,6 +29,9 @@ class Database
     /** @var null|string */
     protected $database;
 
+    /** @var null|string */
+    protected $charset;
+
     /** @var null|\PDO */
     protected $instance;
 
@@ -151,6 +154,28 @@ class Database
     }
 
     /**
+     * Return the charset, if any
+     *
+     * @return null|string
+     */
+    public function getCharSet()
+    {
+        return $this->charset;
+    }
+
+    /**
+     * Set the charset for the database connection
+     *
+     * @param null|string $charset
+     * @return Database
+     */
+    public function setCharset($charset)
+    {
+        $this->charset = $charset;
+        return $this;
+    }
+
+    /**
      * @return int
      */
     public function getErrorMode()
@@ -195,7 +220,8 @@ class Database
                         $this->getDatabase(),
                         $this->getUsername(),
                         $this->getPassword(),
-                        $this->getErrorMode()
+                        $this->getErrorMode(),
+                        $this->getCharSet()
                     );
                     $this->setInstance($instance);
                     break;
@@ -228,14 +254,18 @@ class Database
      * @param string $username
      * @param string $password
      * @param int    $errorMode
+     * @param string $charset
      *
      * @return \Parable\ORM\Database\PDOMySQL
      *
      * @codeCoverageIgnore
      */
-    protected function createPDOMySQL($location, $database, $username, $password, $errorMode)
+    protected function createPDOMySQL($location, $database, $username, $password, $errorMode, $charset)
     {
         $dsn = 'mysql:host=' . $location . ';dbname=' . $database;
+        if ($charset !== null) {
+            $dsn .= ';charset=' . $charset;
+        }
 
         $db  = new \Parable\ORM\Database\PDOMySQL($dsn, $username, $password);
         $db->setAttribute(\PDO::ATTR_ERRMODE, $errorMode);

--- a/src/ORM/Database.php
+++ b/src/ORM/Database.php
@@ -154,19 +154,20 @@ class Database
     }
 
     /**
-     * Return the charset, if any
+     * Return the charset, if set
      *
      * @return null|string
      */
-    public function getCharSet()
+    public function getCharset()
     {
         return $this->charset;
     }
 
     /**
-     * Set the charset for the database connection
+     * Set the charset for the database connection; if not set, database setting is used
      *
      * @param null|string $charset
+     *
      * @return Database
      */
     public function setCharset($charset)


### PR DESCRIPTION
Added charset to the ORM\Database. The config can now have a setting `parable.database.charset`. It's `null` by default, one could argue this should be `utf8` by default. I didn't change any tests, so there goes the code coverage. ;) Anyway, just have a look, this is just a suggestion. 