### PR TITLE
Removed trailing slashes in URLs in isPartCountSame

### DIFF
--- a/src/Routing/Route.php
+++ b/src/Routing/Route.php
@@ -229,7 +229,7 @@ class Route
      */
     public function isPartCountSame($url)
     {
-        return count(explode('/', $url)) === count(explode('/', $this->url));
+        return count(explode('/', rtrim($url, '/'))) === count(explode('/', rtrim($this->url, '/')));
     }
 
     /**


### PR DESCRIPTION
The isPartCountSame method made a difference between a URL with and without trailing slash. This occurred on a route like `/something/{parameter}`. `/something/123` matched but `/something/123/` did not. Now it does.