### PR TITLE
Add `$default` parameter to `\Parable\GetSet\Base::get()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ __Changes__
   - `parable.mail.from.email`, the email for the for address.
   - `parable.mail.from.name`, the name for the for address.
 - `\Parable\GetSet\Base` now also has `setResource`, for when you want to switch, or set it using a method rather than overwriting a property.
+- `\Parable\GetSet\Base::get()` now accepts a second parameter `$default` which is the value to return when the requested `$key` is not found.
 - `\Parable\Http\Request` now has `isOptions()` to check for OPTIONS method requests.
 - `\Parable\Http\Response` now has `setHeaders()` so you can add a bunch of headers in one call, `removeHeader($key)` so you can remove a header, and `clearHeaders()` to, y'know, actually, I think you got this.
 - `\Parable\Http\Response::clearContent()` was added, in case you want to just want to call `appendContent()` multiple times rather than one `setContent()` and then those appends.

--- a/src/GetSet/Base.php
+++ b/src/GetSet/Base.php
@@ -53,22 +53,23 @@ abstract class Base
     }
 
     /**
-     * Return specific value by key if resource set.
+     * Return specific value by key if resource set. If not found, return default.
      *
-     * $getSet->get("one.two.three", "value") would return $resource["one"]["two"]["three"];
+     * $getSet->get("one.two.three", "value") would return $resource["one"]["two"]["three"] or "value";
      *
-     * @param string $key
+     * @param string     $key
+     * @param mixed|null $default
      *
      * @return mixed|null
      */
-    public function get($key)
+    public function get($key, $default = null)
     {
         $resource = $this->getAll();
 
         $keys = explode(".", $key);
         foreach ($keys as $key) {
             if (!isset($resource[$key])) {
-                $resource = null;
+                $resource = $default;
                 break;
             }
             $resource = &$resource[$key];

--- a/tests/Components/GetSet/GetSetTest.php
+++ b/tests/Components/GetSet/GetSetTest.php
@@ -255,4 +255,20 @@ class GetSetTest extends \Parable\Tests\Base
         // But one should be untouched and still an array
         $this->assertTrue(is_array($this->getSet->get("one")));
     }
+
+    public function testGetNonExistingKeyReturnsDefault()
+    {
+        // Test non-existing should still be null
+        $this->assertNull($this->getSet->get("nope"));
+
+        // But with default it should be default
+        $this->assertEquals("default", $this->getSet->get("nope", "default"));
+
+        // Same for nested
+        $this->getSet->set("this", ["totally" => "exists"]);
+
+        $this->assertNull($this->getSet->get("this.doesn't"));
+
+        $this->assertEquals([], $this->getSet->get("this.doesn't", []));
+    }
 }


### PR DESCRIPTION
to return when `$key` not found. Default `null` for BC.