### PR TITLE
Fix arguments

### DIFF
--- a/src/Console/Command.php
+++ b/src/Console/Command.php
@@ -168,7 +168,7 @@ class Command
         $required = Parameter::PARAMETER_OPTIONAL,
         $defaultValue = null
     ) {
-        $this->arguments[$name] = new \Parable\Console\Parameter\Argument($name, $required, $defaultValue);
+        $this->arguments[] = new \Parable\Console\Parameter\Argument($name, $required, $defaultValue);
         return $this;
     }
 

--- a/src/Console/Parameter.php
+++ b/src/Console/Parameter.php
@@ -219,7 +219,7 @@ class Parameter
             }
 
             $argument->setOrder($index);
-            $orderedArguments[$argument->getOrder()] = $argument;
+            $orderedArguments[$index] = $argument;
         }
         $this->commandArguments = $orderedArguments;
 

--- a/tests/Components/Console/AppTest.php
+++ b/tests/Components/Console/AppTest.php
@@ -169,9 +169,9 @@ class AppTest extends \Parable\Tests\Base
         // If default command only, the "command name" should be shifted to the arguments list instead
         $arguments = $this->command1->getArguments();
         if ($defaultCommandOnly) {
-            $this->assertSame("test2", $arguments["arg1"]->getValue());
+            $this->assertSame("test2", $arguments[0]->getValue());
         } else {
-            $this->assertNull($arguments["arg1"]->getValue());
+            $this->assertNull($arguments[0]->getValue());
         }
     }
 

--- a/tests/Components/Console/CommandTest.php
+++ b/tests/Components/Console/CommandTest.php
@@ -77,8 +77,8 @@ class CommandTest extends \Parable\Tests\Base
 
         $arguments = $this->command->getArguments();
 
-        $argument1 = $arguments["arg1"];
-        $argument2 = $arguments["arg2"];
+        $argument1 = $arguments[0];
+        $argument2 = $arguments[1];
 
         $this->assertInstanceOf(\Parable\Console\Parameter\Argument::class, $argument1);
         $this->assertSame("arg1", $argument1->getName());

--- a/tests/Components/Console/ParameterTest.php
+++ b/tests/Components/Console/ParameterTest.php
@@ -241,7 +241,7 @@ class ParameterTest extends \Parable\Tests\Base
             new \Parable\Console\Parameter\Option("option2"),
         ]);
         $this->parameter->setCommandArguments([
-            new \Parable\Console\Parameter\Argument("arg1", \Parable\Console\Parameter::PARAMETER_REQUIRED),
+            new \Parable\Console\Parameter\Argument("brg1", \Parable\Console\Parameter::PARAMETER_REQUIRED),
             new \Parable\Console\Parameter\Argument("arg2", \Parable\Console\Parameter::PARAMETER_OPTIONAL),
             new \Parable\Console\Parameter\Argument("arg3", \Parable\Console\Parameter::PARAMETER_OPTIONAL),
             new \Parable\Console\Parameter\Argument("arg4", \Parable\Console\Parameter::PARAMETER_OPTIONAL),
@@ -260,7 +260,7 @@ class ParameterTest extends \Parable\Tests\Base
         );
         $this->assertSame(
             [
-                'arg1' => 'argument1',
+                'brg1' => 'argument1',
                 'arg2' => 'argument2 is a string',
                 'arg3' => 'argument3!',
                 'arg4' => 'argument4',


### PR DESCRIPTION
Arguments were being added to Command by name.
Arguments were being added to Parameter by index.
Index was thus not an int, but a name.
A non-numerical string converted to int becomes 0.
Thus, all arguments in Parameter were at order 0.
Thus, while there were possibly a lot of arguments in Command, there was only 1 in Parameter.
Why didn't the test pick this up? Because the test case didn't represent the actual situation.
As soon as I added names as keys to the test, it broke.

Solution: don't key by name in Command.
It wasn't used anyway, and the typehint for getArguments was `Argument[]` which implies numerical keys.
Not adding a changelog, because the bug was introduced earlier in PR #27 and hadn't reached master yet.