### PR TITLE
Fix getOption() and getProvidedValue() for they break on falsy values.

### DIFF
--- a/src/Console/Parameter.php
+++ b/src/Console/Parameter.php
@@ -180,7 +180,7 @@ class Parameter
 
         $option = $this->commandOptions[$name];
 
-        if ($option->hasBeenProvided() && !$option->getProvidedValue() && !$option->getDefaultValue()) {
+        if ($option->hasBeenProvided() && $option->getProvidedValue() === null && $option->getDefaultValue() === null) {
             return true;
         }
 

--- a/src/Console/Parameter/Base.php
+++ b/src/Console/Parameter/Base.php
@@ -148,7 +148,7 @@ abstract class Base
      */
     public function getValue()
     {
-        if ($this->getProvidedValue()) {
+        if ($this->getProvidedValue() !== null) {
             return $this->getProvidedValue();
         }
 

--- a/tests/Components/Console/ParameterTest.php
+++ b/tests/Components/Console/ParameterTest.php
@@ -349,4 +349,59 @@ class ParameterTest extends \Parable\Tests\Base
             418
         );
     }
+
+    /**
+     * @dataProvider dpGetOptionReturnsExpected
+     *
+     * @param string $parameter As provoked from cli
+     * @param mixed  $default   Option default
+     * @param mixed  $expected  Expected result
+     */
+    public function testGetOptionReturnsExpected($parameter, $default, $expected)
+    {
+        $parameters = [
+            './test.php',
+            'command-to-run',
+        ];
+
+        if (!empty($parameter)) {
+            $parameters[] = $parameter;
+        }
+
+        $this->parameter->setParameters($parameters);
+        $this->parameter->setCommandOptions([
+            'option' => new \Parable\Console\Parameter\Option(
+                "option",
+                \Parable\Console\Parameter::PARAMETER_OPTIONAL,
+                \Parable\Console\Parameter::OPTION_VALUE_OPTIONAL,
+                $default
+            ),
+        ]);
+
+        $this->parameter->checkCommandOptions();
+
+        $this->assertEquals($expected, $this->parameter->getOption('option'));
+    }
+
+    /**
+     * This does not test the case where the option doesn't exist.
+     *
+     * @return array
+     */
+    public function dpGetOptionReturnsExpected()
+    {
+        return [
+            ['', null, null],
+            ['', 0, 0],
+            ['', '0', '0'],
+            ['', false, false],
+            ['--option', null, true], // This is "flag"-style
+            ['--option', 0, 0],
+            ['--option', '0', '0'],
+            ['--option', false, false],
+            ['--option=null', null, 'null'],
+            ['--option=0', null, '0'],
+            ['--option=false', null, 'false'],
+        ];
+    }
 }


### PR DESCRIPTION
See new test, dp-testcases with index 5, 6, 7, and 9 fail without these changes.