### PR TITLE
Command now follows general guidelines for parameters:

### DIFF
--- a/src/Console/Parameter/Option.php
+++ b/src/Console/Parameter/Option.php
@@ -32,12 +32,29 @@ class Option extends Base
             [
                 \Parable\Console\Parameter::OPTION_VALUE_REQUIRED,
                 \Parable\Console\Parameter::OPTION_VALUE_OPTIONAL,
+                \Parable\Console\Parameter::OPTION_FLAG,
             ]
         )) {
-            throw new \Parable\Console\Exception('Value required must be one of the OPTION_VALUE_* constants.');
+            throw new \Parable\Console\Exception('Value required must be one of the OPTION_* constants.');
         }
         $this->valueRequired = $valueRequired;
         return $this;
+    }
+
+    public function setIsFlag()
+    {
+        $this->valueRequired = \Parable\Console\Parameter::OPTION_FLAG;
+        return $this;
+    }
+
+    /**
+     * Return whether the option is a flag.
+     *
+     * @return bool
+     */
+    public function isFlag()
+    {
+        return $this->valueRequired === \Parable\Console\Parameter::OPTION_FLAG;
     }
 
     /**

--- a/tests/Components/Console/ParameterTest.php
+++ b/tests/Components/Console/ParameterTest.php
@@ -615,5 +615,4 @@ class ParameterTest extends \Parable\Tests\Base
             $this->parameter->getOptions()
         );
     }
-
 }


### PR DESCRIPTION
* added short options (flags)
* possibility to pass multiple option flags in a single parameter (-abc same as -a -b -c)
* combined option flags are read until the first option value is met
* option values can also be passed using a space ('=' is not required)
* '--' means the end of options; all following parameters are interpreted as arguments