### PR TITLE
Making parseUrlParameters public

### DIFF
--- a/src/Routing/Route.php
+++ b/src/Routing/Route.php
@@ -278,7 +278,7 @@ class Route
      *
      * @return $this
      */
-    protected function parseUrlParameters()
+    public function parseUrlParameters()
     {
         $urlParts = explode('/', $this->url);
         $this->parameters = [];


### PR DESCRIPTION
This way a Route can be added dynamically by populating a Route. Don't forget to call `parseUrlParameters` if the route URL has parameters (stuff between curly braces, that is).

Erm, do you need an extra Test for this?